### PR TITLE
Refactor flow schema to use codes

### DIFF
--- a/db/00-init-ddl.sql
+++ b/db/00-init-ddl.sql
@@ -12,6 +12,7 @@ create table if not exists heroes.cycle
 (
   id      serial primary key,
   code    text unique not null, -- 'MIN30' | 'H1' | 'H2'
+  name    text        not null,
   minutes int         not null check (minutes > 0)
 );
 
@@ -22,32 +23,26 @@ create table if not exists heroes.resource
   name text        not null
 );
 
-create table if not exists heroes.building_type
+create table if not exists heroes.building
 (
   id         serial primary key,
   code       text unique not null, -- 'MOTH_GLADE', 'RICE_FARM', ...
   name       text        not null,
   culture_id int         not null references heroes.culture (id) on delete cascade
 );
--- 3) Конкретные уровни зданий в локации
-create table if not exists heroes.building
-(
-  id    serial primary key,
-  type  int not null references heroes.building_type (id) on delete cascade,
-  level int not null check (level >= 1),
-  unique (type, level)
-);
 
 -- 4) Потоки ресурсов по зданиям/уровням/интервалам.
 --    quantity > 0  -> производит; quantity < 0 -> потребляет.
 create table if not exists heroes.flow
 (
-  building_id int            not null references heroes.building (id) on delete cascade,
-  resource_id int            not null references heroes.resource (id) on delete cascade,
-  cycle_id    int            not null references heroes.cycle (id) on delete cascade,
-  quantity    numeric(18, 6) not null, -- штук за интервал
-  primary key (building_id, cycle_id, resource_id)
+  culture  text           not null references heroes.culture (code) on delete cascade,
+  building text           not null references heroes.building (code) on delete cascade,
+  level    int            not null check (level >= 1),
+  resource text           not null references heroes.resource (code) on delete cascade,
+  cycle    text           not null references heroes.cycle (code) on delete cascade,
+  quantity numeric(18, 6) not null, -- штук за интервал
+  primary key (culture, building, level, resource, cycle)
 );
 -- 5) Индексы-ускорители
-create index if not exists ix_flow_res on heroes.flow (resource_id);
+create index if not exists ix_flow_res on heroes.flow (resource);
 

--- a/db/01-init-dml.sql
+++ b/db/01-init-dml.sql
@@ -1,130 +1,58 @@
 -- heroes_init_china.sql
 -- DML инициализация данных под обновлённую модель:
---   culture/cycle/resource/building_type/building/flow
+--   culture/cycle/resource/building/flow
 -- Локация теперь называется culture (пример: CHINA).
 -- === Базовые справочники ===
 insert into heroes.culture(code, name) values ('CHINA', 'China') on conflict (code) do update set name = excluded.name;
 
-insert into heroes.cycle(code, minutes)
-values ('MIN30', 30), ('H1', 60), ('H2', 120)
-    on conflict (code) do update set minutes = excluded.minutes;
+insert into heroes.cycle(code, name, minutes)
+values ('MIN30', '30 minutes', 30), ('H1', '1 hour', 60), ('H2', '2 hours', 120)
+    on conflict (code) do update set name = excluded.name, minutes = excluded.minutes;
 
 insert into heroes.resource(code, name)
 values ('MOTH_COCOON', 'Moth cocoon'), ('RICE', 'Rice'), ('THREAD', 'Thread'), ('SILK', 'Silk')
     on conflict (code) do update set name = excluded.name;
--- === Типы зданий для культуры CHINA ===
+-- === Здания для культуры CHINA ===
   with c as (select id from heroes.culture where code = 'CHINA')
 insert
-  into heroes.building_type(code, name, culture_id)
+  into heroes.building(code, name, culture_id)
 values ('MOTH_GLADE', 'Moth Glade', (select id from c)),
        ('RICE_FARM', 'Rice Farm', (select id from c)),
        ('THREAD_PROCESSOR', 'Thread Processor', (select id from c)),
        ('SILK_WORKSHOP', 'Silk Workshop', (select id from c))
     on conflict (code) do update set name = excluded.name, culture_id = excluded.culture_id;
--- === Конкретные уровни зданий ===
-  with bt  as (select id, code from heroes.building_type),
-       ins
-           as ( insert into heroes.building (type, level) select (select id from bt where code = 'MOTH_GLADE'), 3 on conflict (type, level) do nothing returning id)
-select *
-  from ins;
-  
-  with bt  as (select id, code from heroes.building_type),
-       ins
-           as ( insert into heroes.building (type, level) select (select id from bt where code = 'RICE_FARM'), 2 on conflict (type, level) do nothing returning id)
-select *
-  from ins;
-  
-  with bt  as (select id, code from heroes.building_type),
-       ins
-           as ( insert into heroes.building (type, level) select (select id from bt where code = 'THREAD_PROCESSOR'), 2 on conflict (type, level) do nothing returning id)
-select *
-  from ins;
-  
-  with bt  as (select id, code from heroes.building_type),
-       ins
-           as ( insert into heroes.building (type, level) select (select id from bt where code = 'SILK_WORKSHOP'), 3 on conflict (type, level) do nothing returning id)
-select *
-  from ins;
 
 -- === Потоки (cycle = H1, 60 минут) ===
 -- Положительное значение -> производит; отрицательное -> потребляет.
 -- Moth Glade L3: +1033 MOTH_COCOON
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, 1033.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'MOTH_GLADE'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'MOTH_COCOON'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 3
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'MOTH_GLADE', 3, 'MOTH_COCOON', 'H1', 1033.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;
 -- Rice Farm L2: +375 RICE
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, 375.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'RICE_FARM'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'RICE'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 2
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'RICE_FARM', 2, 'RICE', 'H1', 375.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;
 -- Thread Processor L2: +200 THREAD, -270 RICE, -910 MOTH_COCOON
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, 200.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'THREAD_PROCESSOR'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'THREAD'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 2
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'THREAD_PROCESSOR', 2, 'THREAD', 'H1', 200.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;
 
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, -270.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'THREAD_PROCESSOR'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'RICE'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 2
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'THREAD_PROCESSOR', 2, 'RICE', 'H1', -270.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;
 
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, -910.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'THREAD_PROCESSOR'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'MOTH_COCOON'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 2
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'THREAD_PROCESSOR', 2, 'MOTH_COCOON', 'H1', -910.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;
 -- Silk Workshop L3: +270 SILK, -490 THREAD, -580 RICE
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, 270.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'SILK_WORKSHOP'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'SILK'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 3
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'SILK_WORKSHOP', 3, 'SILK', 'H1', 270.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;
 
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, -490.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'SILK_WORKSHOP'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'THREAD'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 3
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'SILK_WORKSHOP', 3, 'THREAD', 'H1', -490.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;
 
-insert into heroes.flow(building_id, resource_id, cycle_id, quantity)
-select b.id, r.id, cy.id, -580.0
-  from heroes.building b
-       join heroes.building_type bt on bt.id = b.type and bt.code = 'SILK_WORKSHOP'
-       join heroes.culture cu on cu.id = bt.culture_id and cu.code = 'CHINA'
-       join heroes.resource r on r.code = 'RICE'
-       join heroes.cycle cy on cy.code = 'H1'
- where b.level = 3
-    on conflict (building_id, cycle_id, resource_id) do update set quantity = excluded.quantity;
+insert into heroes.flow(culture, building, level, resource, cycle, quantity)
+values ('CHINA', 'SILK_WORKSHOP', 3, 'RICE', 'H1', -580.0)
+    on conflict (culture, building, level, resource, cycle) do update set quantity = excluded.quantity;

--- a/db/02-migrate-to-flow-codes.sql
+++ b/db/02-migrate-to-flow-codes.sql
@@ -1,0 +1,65 @@
+-- Миграция со старой схемы (building_type/building/flow с ID) на схему с кодами.
+begin;
+
+-- 1) Добавляем человекочитаемое имя циклам, если его ещё нет.
+alter table heroes.cycle add column if not exists name text;
+update heroes.cycle set name = coalesce(name, code);
+alter table heroes.cycle alter column name set not null;
+
+-- 2) Подготавливаем новую таблицу справочника зданий (бывший building_type).
+create table if not exists heroes.building_new
+(
+  id         serial primary key,
+  code       text unique not null,
+  name       text        not null,
+  culture_id int         not null references heroes.culture (id) on delete cascade
+);
+
+insert into heroes.building_new(code, name, culture_id)
+select bt.code, bt.name, bt.culture_id
+  from heroes.building_type bt
+on conflict (code) do update set name = excluded.name, culture_id = excluded.culture_id;
+
+-- 3) Переносим потоки в новую структуру, где ключом служат коды.
+create table if not exists heroes.flow_new
+(
+  culture  text           not null references heroes.culture (code) on delete cascade,
+  building text           not null references heroes.building_new (code) on delete cascade,
+  level    int            not null check (level >= 1),
+  resource text           not null references heroes.resource (code) on delete cascade,
+  cycle    text           not null references heroes.cycle (code) on delete cascade,
+  quantity numeric(18, 6) not null,
+  primary key (culture, building, level, resource, cycle)
+);
+
+insert into heroes.flow_new(culture, building, level, resource, cycle, quantity)
+select cu.code,
+       bt.code,
+       b.level,
+       r.code,
+       cy.code,
+       f.quantity
+  from heroes.flow f
+       join heroes.building b on b.id = f.building_id
+       join heroes.building_type bt on bt.id = b.type
+       join heroes.culture cu on cu.id = bt.culture_id
+       join heroes.resource r on r.id = f.resource_id
+       join heroes.cycle cy on cy.id = f.cycle_id
+on conflict (culture, building, level, resource, cycle)
+  do update set quantity = excluded.quantity;
+
+-- 4) Удаляем больше не используемые таблицы и переименовываем новые.
+drop table if exists heroes.flow;
+drop table if exists heroes.building;
+drop table if exists heroes.building_type;
+
+drop sequence if exists heroes.building_id_seq;
+drop sequence if exists heroes.building_type_id_seq;
+
+alter table heroes.building_new rename to building;
+alter sequence if exists heroes.building_new_id_seq rename to building_id_seq;
+
+alter table heroes.flow_new rename to flow;
+create index if not exists ix_flow_res on heroes.flow (resource);
+
+commit;


### PR DESCRIPTION
## Summary
- refactor the schema to store flow keys using culture/building/resource/cycle codes and expose cycle names
- update seed data and add a migration script that moves existing data into the new structure
- adjust the Python optimizer to work with code-based flow keys instead of numeric IDs

## Testing
- python -m compileall src/heroes/core/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a81c4cf083258431a0e57d31af2f